### PR TITLE
Changed Do While to Repeat While

### DIFF
--- a/README.md
+++ b/README.md
@@ -1144,10 +1144,10 @@ while someTestCondition {
 }
 ```
 
-#### Do While Loop
+#### Repeat While Loop
 
 ```swift
-do {
+repeat {
     // Code to execute while the condition is true
 } while someTestCondition
 ```


### PR DESCRIPTION
The `do` keyword is used for error handling since Swift 2, so they renamed `do while` to `repeat while`.
