### PR TITLE
Removed explicit NSUserDefaults synchronize calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1205,10 +1205,7 @@ User defaults are basically a way of storing simple preference values which can 
 ```swift
 let userDefaults = NSUserDefaults.standardUserDefaults()
 userDefaults.setValue("Some Value", forKey: "RPSomeUserPreference")
-userDefaults.synchronize()
 ```
-
-Always remember to call `synchronize` on the defaults instance to ensure they are saved properly.
 
 ### Retrieving Values
 


### PR DESCRIPTION
Calling synchronize on NSUserDefaults is no longer required. 
Details: https://twitter.com/Catfish_Man/status/510122371995299840
